### PR TITLE
Honor the audio tag's `preload` attribute

### DIFF
--- a/picobel.js
+++ b/picobel.js
@@ -108,6 +108,7 @@ function Picobel( options ) {
             item = {};
             // Get the file's URL
             item.url = data[i].src;
+            item.preload = data[i].preload;
             output.push( item );
         }
         return output;
@@ -257,7 +258,9 @@ function Picobel( options ) {
 
         for ( var i = 0; i < data.length; i++ ) {
             // Init. the audio
-            myAudio[i] = new Audio( data[i].url );
+            myAudio[i] = new Audio();
+            if (data[i].preload) myAudio[i].preload = data[i].preload;
+            myAudio[i].src = data[i].url;
             
             // Check if file exists before setting time, to prevent IE11 error
             if (!isNaN(myAudio[i].duration)) {

--- a/picobel.js
+++ b/picobel.js
@@ -108,7 +108,7 @@ function Picobel( options ) {
             item = {};
             // Get the file's URL
             item.url = data[i].src;
-            item.preload = data[i].preload;
+            item.preload = options.preload ? options.preload : data[i].preload;
             output.push( item );
         }
         return output;


### PR DESCRIPTION
Fixes: the audio tag's preload attribute is ignored, which leads to automatically loading all files fully at load time. This can load 100s of megabytes of data. Not ideal.

The change mirrors the `preload` setting from the document's <audio> tag into the newly created Audio object.