### PR TITLE
Re-export types

### DIFF
--- a/packages/picobel/src/js/react/index.tsx
+++ b/packages/picobel/src/js/react/index.tsx
@@ -1,3 +1,4 @@
 export * from "./core/provider";
 export { default } from "./core/PicobelWrapper";
 export * from "./components";
+export type * from "./core/types";


### PR DESCRIPTION
TS was complaining that some types related to the context didn’t exist, so here you go