### PR TITLE
fix: guard against undefined audioRef in useTrackEventListeners

### DIFF
--- a/packages/picobel/src/js/react/tracks/trackListeners.ts
+++ b/packages/picobel/src/js/react/tracks/trackListeners.ts
@@ -15,7 +15,7 @@ export const useTrackEventListeners = (
 
         // Set up event listeners for each track
         Object.entries(tracks).forEach(([id, track]) => {
-            const audioEl = track.audioRef.current;
+            const audioEl = track.audioRef?.current;
             if (!audioEl) return;
 
             // Time update handler


### PR DESCRIPTION
## What

`useTrackEventListeners` reads `track.audioRef.current` directly while iterating tracks:

```ts
Object.entries(tracks).forEach(([id, track]) => {
    const audioEl = track.audioRef.current; // throws if track.audioRef is undefined
    if (!audioEl) return;
```

If a track entry exists in state without an `audioRef`, this throws:

```
TypeError: undefined is not an object (evaluating 'track.audioRef.current')
```

We hit this in production (Safari, React 19) — the error fires from the effect during React's commit phase.

## Fix

Optional chaining, so a missing `audioRef` falls through the existing null guard instead of crashing:

```ts
const audioEl = track.audioRef?.current;
if (!audioEl) return;
```

One-line, defensive change in `packages/picobel/src/js/react/tracks/trackListeners.ts`. Build artifacts left untouched for a release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)